### PR TITLE
⚡ レスポンスのステータスコードチェック処理を修正

### DIFF
--- a/upload_to_onedrive/upload.py
+++ b/upload_to_onedrive/upload.py
@@ -1,6 +1,7 @@
 import requests
 
 from graph_auth import read_token
+from graph_auth import ApiError
 
 
 def upload(user_id: str, upload_file_path: str, upload_dest_file_path: str):
@@ -9,15 +10,11 @@ def upload(user_id: str, upload_file_path: str, upload_dest_file_path: str):
     url = f"https://graph.microsoft.com/v1.0/users/{user_id}/drive/items/root:/{upload_dest_file_path}:/content"
 
     # APIの実行
-    try:
-        response = requests.put(url, data=read_file(upload_file_path), headers=header)
-    except Exception:
-        print("An error occurred during requesting for api")
+    response = requests.put(url, data=read_file(upload_file_path), headers=header)
 
     # レスポンスのチェック
-    if response.status_code != 201:
-        print("reponse status is not correct")
-        print(response._content.decode(encoding="utf-8"))
+    if response.status_code not in (200, 201):
+        raise ApiError(response)
 
     return response
 

--- a/upload_to_onedrive/upload.py
+++ b/upload_to_onedrive/upload.py
@@ -14,8 +14,6 @@ def upload(user_id: str, upload_file_path: str, upload_dest_file_path: str):
     except Exception:
         print("An error occurred during requesting for api")
 
-    print(response.__dict__)
-
     # レスポンスのチェック
     if response.status_code != 201:
         print("reponse status is not correct")


### PR DESCRIPTION
アップロードが新規に完了したステータスコード201のみ許容していたが、
アップロード時にファイルを上書きした場合、200が返る挙動だったので、
200も許容するように修正